### PR TITLE
Use correct namespace on StatusCode enum

### DIFF
--- a/examples/get_request_simple.cpp
+++ b/examples/get_request_simple.cpp
@@ -16,8 +16,8 @@ int main() {
         // TODO: replace with this when GCC supports std::format
         // utils::println("\nHeaders {}: \n{}", response_count++, response.get_headers_string());
 
-        if (response.get_status_code() == StatusCode::MovedPermanently ||
-            response.get_status_code() == StatusCode::Found) 
+        if (response.get_status_code() == http_client::StatusCode::MovedPermanently ||
+            response.get_status_code() == http_client::StatusCode::Found) 
         {
             if (auto const new_url = response.get_header_value("location")) {
                 url = *new_url;


### PR DESCRIPTION
I use the CMake FetchContent to retrieve this library in my project. I'm trying out the [example code](https://github.com/avocadoboi/cpp20-http-client/blob/master/examples/get_request_simple.cpp) for 30x redirects, but it didn't compile. I found out the code is missing the namespace.

```cpp
main.cpp:16:43: error: ‘StatusCode’ has not been declared
         if (response.get_status_code() == StatusCode::MovedPermanently ||
                                           ^~~~~~~~~~
main.cpp:17:43: error: ‘StatusCode’ has not been declared
             response.get_status_code() == StatusCode::Found)
```

My CMakeLists.txt:

```CMake
# Download external dependency
FetchContent_Declare(
    Cpp20HttpClient
    GIT_REPOSITORY https://github.com/avocadoboi/cpp20-http-client.git
)
FetchContent_MakeAvailable(Cpp20HttpClient)

# Link HTTP Client for C++20
target_link_libraries(${PROJECT_TARGET} Cpp20HttpClient::cpp20_http_client)
```