### PR TITLE
Add three options to disable: examples, tests and install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ project(Cpp20HttpClient VERSION 2.1.1 LANGUAGES CXX)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib/)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin/)
 
+# Project specific options
+option(CCPP20_HTTP_CLIENT_BUILD_EXAMPLES "Set to OFF to not build examples" ON)
+option(CCPP20_HTTP_CLIENT_BUILD_TESTS "Set to OFF to not build tests" ON)
+option(CCPP20_HTTP_CLIENT_ENABLE_INSTALL "Generate the install target" ON)
+
 #-----------------------------
 # Library target.
 
@@ -40,61 +45,65 @@ endif ()
 
 if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 	include(CTest)
-	if (BUILD_TESTING)
+	if (BUILD_TESTING AND CCPP20_HTTP_CLIENT_BUILD_TESTS)
 		add_subdirectory(tests)
 	endif ()
 endif ()
 
-add_subdirectory(examples)
+if (CCPP20_HTTP_CLIENT_BUILD_EXAMPLES)
+	add_subdirectory(examples)
+endif ()
 
 #-----------------------------
 # Set up installation.
 
 include(CMakePackageConfigHelpers)
 
-# Create a file that contains information about package versioning.
-# It will be placed in CMAKE_CURRENT_BINARY_DIR.
-write_basic_package_version_file(
-	${PROJECT_NAME}ConfigVersion.cmake
-	VERSION ${PROJECT_VERSION}
-	COMPATIBILITY AnyNewerVersion
-)
-# During installation, the version file will be installed.
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-	DESTINATION lib/cmake/${PROJECT_NAME}) # Relative to the installation path.
-
-set(TARGET_EXPORT_NAME ${PROJECT_NAME}Targets)
-
-# Specifies the target(s) that will be installed, and where to install 
-# the compiled library (relative to package installation path ${CMAKE_INSTALL_PREFIX}).
-install(
-	TARGETS cpp20_http_client
-	EXPORT ${TARGET_EXPORT_NAME} 
-	ARCHIVE DESTINATION lib
-)
+if (CCPP20_HTTP_CLIENT_ENABLE_INSTALL)
+	# Create a file that contains information about package versioning.
+	# It will be placed in CMAKE_CURRENT_BINARY_DIR.
+	write_basic_package_version_file(
+		${PROJECT_NAME}ConfigVersion.cmake
+		VERSION ${PROJECT_VERSION}
+		COMPATIBILITY AnyNewerVersion
+	)
+	# During installation, the version file will be installed.
+	install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+		DESTINATION lib/cmake/${PROJECT_NAME}) # Relative to the installation path.
 	
-# During installation, a target configuration file will be exported to a *Targets.cmake file
-# that is included by the *Config.cmake.in file which finds the dependencies of the library.
-install(
-	EXPORT ${TARGET_EXPORT_NAME}
-	FILE ${TARGET_EXPORT_NAME}.cmake
-	NAMESPACE ${PROJECT_NAME}::
-	DESTINATION lib/cmake/${PROJECT_NAME} # Relative to installation path
-)
-
-# This uses the *Config.cmake.in file to generate a *Config.cmake file with 
-# the variables specified by PATH_VARS inserted.
-configure_package_config_file(
-	cmake/${PROJECT_NAME}Config.cmake.in
-	${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-	INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
-	PATH_VARS TARGET_EXPORT_NAME
-)
-
-# Install the config file 
-install(
-	FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-	DESTINATION lib/cmake/${PROJECT_NAME}
-)
-
-install(DIRECTORY include DESTINATION .)
+	set(TARGET_EXPORT_NAME ${PROJECT_NAME}Targets)
+	
+	# Specifies the target(s) that will be installed, and where to install 
+	# the compiled library (relative to package installation path ${CMAKE_INSTALL_PREFIX}).
+	install(
+		TARGETS cpp20_http_client
+		EXPORT ${TARGET_EXPORT_NAME} 
+		ARCHIVE DESTINATION lib
+	)
+		
+	# During installation, a target configuration file will be exported to a *Targets.cmake file
+	# that is included by the *Config.cmake.in file which finds the dependencies of the library.
+	install(
+		EXPORT ${TARGET_EXPORT_NAME}
+		FILE ${TARGET_EXPORT_NAME}.cmake
+		NAMESPACE ${PROJECT_NAME}::
+		DESTINATION lib/cmake/${PROJECT_NAME} # Relative to installation path
+	)
+	
+	# This uses the *Config.cmake.in file to generate a *Config.cmake file with 
+	# the variables specified by PATH_VARS inserted.
+	configure_package_config_file(
+		cmake/${PROJECT_NAME}Config.cmake.in
+		${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+		INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
+		PATH_VARS TARGET_EXPORT_NAME
+	)
+	
+	# Install the config file 
+	install(
+		FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+		DESTINATION lib/cmake/${PROJECT_NAME}
+	)
+	
+	install(DIRECTORY include DESTINATION .)
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,9 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib/)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin/)
 
 # Project specific options
-option(CCPP20_HTTP_CLIENT_BUILD_EXAMPLES "Set to OFF to not build examples" ON)
-option(CCPP20_HTTP_CLIENT_BUILD_TESTS "Set to OFF to not build tests" ON)
-option(CCPP20_HTTP_CLIENT_ENABLE_INSTALL "Generate the install target" ON)
+option(CPP20_HTTP_CLIENT_BUILD_EXAMPLES "Set to OFF to not build examples" ON)
+option(CPP20_HTTP_CLIENT_BUILD_TESTS "Set to OFF to not build tests" ON)
+option(CPP20_HTTP_CLIENT_ENABLE_INSTALL "Generate the install target" ON)
 
 #-----------------------------
 # Library target.
@@ -45,12 +45,12 @@ endif ()
 
 if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 	include(CTest)
-	if (BUILD_TESTING AND CCPP20_HTTP_CLIENT_BUILD_TESTS)
+	if (BUILD_TESTING AND CPP20_HTTP_CLIENT_BUILD_TESTS)
 		add_subdirectory(tests)
 	endif ()
 endif ()
 
-if (CCPP20_HTTP_CLIENT_BUILD_EXAMPLES)
+if (CPP20_HTTP_CLIENT_BUILD_EXAMPLES)
 	add_subdirectory(examples)
 endif ()
 
@@ -59,7 +59,7 @@ endif ()
 
 include(CMakePackageConfigHelpers)
 
-if (CCPP20_HTTP_CLIENT_ENABLE_INSTALL)
+if (CPP20_HTTP_CLIENT_ENABLE_INSTALL)
 	# Create a file that contains information about package versioning.
 	# It will be placed in CMAKE_CURRENT_BINARY_DIR.
 	write_basic_package_version_file(


### PR DESCRIPTION
Introducing three options (by default set to: `ON` aka 'true'), allowing users to disable; examples, tests and install.

Fixes: https://github.com/avocadoboi/cpp20-http-client/issues/8